### PR TITLE
Add [DebuggerStepThrough] to RandomFailureMiddleware

### DIFF
--- a/Products/Program.cs
+++ b/Products/Program.cs
@@ -1,7 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Products.Data;
 using Products.Endpoints;
-
+using System.Diagnostics;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/Products/Program.cs
+++ b/Products/Program.cs
@@ -28,7 +28,7 @@ app.CreateDbIfNotExists();
 
 app.Run();
 
-
+[DebuggerStepThrough]
 public class RandomFailureMiddleware : IMiddleware
 {
 	public Task InvokeAsync(HttpContext context, RequestDelegate next)


### PR DESCRIPTION
Prevent breaking in Visual Studio when exception is thrown.

* [`Products/Program.cs`](diffhunk://#diff-844f1bc7f0f6860eb949fa189d13d1daca34929482f7a8955412151128cab449L31-R31): Added the `[DebuggerStepThrough]` attribute to the `RandomFailureMiddleware` class.

